### PR TITLE
Lombok plugin 8.0.1 -> 8.4

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("application")
     id("org.openjfx.javafxplugin") version "0.0.14"
-    id("io.freefair.lombok") version "8.0.1"
+    id("io.freefair.lombok") version "8.4"
     id("com.needhamsoftware.unojar") version "1.1.0"
 }
 


### PR DESCRIPTION
This is required to avoid build errors on OpenJDK 21+

Example error:
```
* What went wrong:
Execution failed for task ':compileJava'.
> java.lang.NoSuchFieldError: Class com.sun.tools.javac.tree.JCTree$JCImport does not have member field 'com.sun.tools.javac.tree.JCTree qualid'
```

The underlying fix is [apparently](https://stackoverflow.com/a/77171271) to bump Lombok 1.18.30